### PR TITLE
Fixed issue where a terminated EC2 instance would generate a KeyError when trying to find its VpcId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Results files
+*.html
+*.dot

--- a/graph_region.py
+++ b/graph_region.py
@@ -179,7 +179,8 @@ class AWSVisualizer:
         self.reservations = self.EC2.describe_instances()['Reservations']
         for r in self.reservations:
             for i in r['Instances']:
-                self.instances.append(EC2Instance(i))
+                if i['State']['Name'] != "terminated":
+                    self.instances.append(EC2Instance(i))
 
         self.load_all_ips()
         self.load_subnets()


### PR DESCRIPTION
If you run aws-visualizer in a VPC with terminated EC2 instances, you will get a KeyError when get_instances_in_vpc() tries to filter on VpcId as terminated instances lack that key. Filtering terminated instances out in load() solves this issue.